### PR TITLE
Update readme to refer to latest version of Visual Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Open the command palette
 
 Select `Tasks: Run Test Task`
 
-## Visual Studio 2017 (Windows)
+## Visual Studio 2019 (Windows)
 Open `csharp-interview-prep.sln`
 
 Open Test Explorer


### PR DESCRIPTION
Update README to refer to latest version of Visual Studio so candidates don't think we require running on an older version