### PR TITLE
Upgrade to .NET 6 for C# interviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ setup.
 
 # Getting Ready
 
-If you have not already, please install [.NET 5.0](https://dotnet.microsoft.com/en-us/download/dotnet/5.0)
+If you have not already, please install [.NET 6.0](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
 
-This solution supports the following  development environments.
+This solution supports the following development environments.
 
 ## Console (Windows, Linux, OSX)
 in the directory of the repo run

--- a/lib/lib.csproj
+++ b/lib/lib.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 </Project>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
When I was interviewing at Stripe, I was using an M1 mac which isn't supported on .NET5. This upgrades the interview setup to .NET 6 which is an LTS supported release.

Also updating Newtonsoft.Json.