### PR TITLE
Update to Dotnet 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ setup.
 
 If you have not already, please install [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
 
-This solution supports the following  development environments.
+This solution supports the following development environments.
 
 ## Console (Windows, Linux, OSX)
 in the directory of the repo run
@@ -35,7 +35,7 @@ Open the command palette
 
 Select `Tasks: Run Test Task`
 
-## Visual Studio 2019 (Windows)
+## Visual Studio 2022 (Windows)
 Open `csharp-interview-prep.sln`
 
 Open Test Explorer
@@ -47,7 +47,7 @@ This project uses xUnit for implementing and executing tests.
 
 # About This Project:
 
-## I prefer .Net Framework 6/nUnit/Bespoke Powershell Scripts, do I need to use this?
+## I prefer nUnit/Bespoke Powershell Scripts, do I need to use this?
 
 If you prefer different configuration files, that's awesome.
 Some interview questions may ask to implement something from nothing,

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ setup.
 
 # Getting Ready
 
-If you have not already, please install [.NET 5.0](https://dotnet.microsoft.com/en-us/download/dotnet/5.0)
+If you have not already, please install [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
 
 This solution supports the following  development environments.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ setup.
 
 # Getting Ready
 
-If you have not already, please install [.NET 7.0](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
+If you have not already, please install [.NET 8.0](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 
 This solution supports the following development environments.
 
@@ -50,7 +50,7 @@ This project uses xUnit for implementing and executing tests.
 ## I prefer nUnit/Bespoke Powershell Scripts, do I need to use this?
 
 If you prefer different configuration files, that's awesome.
-Some interview questions may ask to implement something from nothing,
+Some interview questions may ask you to implement something from nothing,
 and some may want to watch you interact with a pre-existing codebase.
 For the former, it doesn't matter what you use, as long as you're able
 to get things setup quickly.

--- a/csharp-interview-prep.sln
+++ b/csharp-interview-prep.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.0.31903.59
-MinimumVisualStudioVersion = 15.0.26124.0
+VisualStudioVersion = 17.8
+MinimumVisualStudioVersion = 17.8
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "lib", "lib\lib.csproj", "{4D8FEF9D-17A9-40B7-85A1-6D32ACCCB50F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "tests\tests.csproj", "{25AA2B08-9560-4E59-A9DE-FF02B4E96406}"

--- a/csharp-interview-prep.sln
+++ b/csharp-interview-prep.sln
@@ -1,7 +1,7 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "lib", "lib\lib.csproj", "{4D8FEF9D-17A9-40B7-85A1-6D32ACCCB50F}"
 EndProject

--- a/lib/lib.csproj
+++ b/lib/lib.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/lib/lib.csproj
+++ b/lib/lib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates to Dotnet 8.0

## Context

- Dotnet 5.0 is currently unsupported and does not work on Apple silicon.
- The bug squash interview for C# was previously updated to 7.0 but the interview prep is currently out of sync, causing issues for candidates: https://github.com/stripe-interview/refit
- The bug squash instructions will be updated to reference the new 8.0 requirement following this PR: https://confluence.corp.stripe.com/pages/viewpage.action?pageId=74826403

## This PR

- Updates the project to dotnet 8.0
- Bumps up `Microsoft.NET.Test.Sdk` to `17.8.0`
- Bumps up `xunit` to `2.6.6`
- Bumps up `xunit.runner.visualstudio` to `2.5.6`
- Bumps up `Newtonsoft.Json` to `13.0.3`
- Sets the minimum Visual Studio version to `17.8` as this is the minimum version required for dotnet 8.0

## Test

Build and Test output:

```
02:55:44 samiz@st-samiz2 csharp-interview-prep ±|samiz-dotnet-7 ✗|→ dotnet restore
  Determining projects to restore...
  Restored /Users/samiz/stripe/csharp-interview-prep/lib/lib.csproj (in 4.69 sec).
  Restored /Users/samiz/stripe/csharp-interview-prep/tests/tests.csproj (in 6.28 sec).
02:56:02 samiz@st-samiz2 csharp-interview-prep ±|samiz-dotnet-7 ✗|→ dotnet clean
MSBuild version 17.8.3+195e7f5a3 for .NET
Build started 1/19/2024 2:56:06 PM.
     1>Project "/Users/samiz/stripe/csharp-interview-prep/csharp-interview-prep.sln" on node 1 (Clean target(s)).
     1>ValidateSolutionConfiguration:
         Building solution configuration "Debug|Any CPU".
     1>Done Building Project "/Users/samiz/stripe/csharp-interview-prep/csharp-interview-prep.sln" (Clean target(s)).

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:00.40
02:56:07 samiz@st-samiz2 csharp-interview-prep ±|samiz-dotnet-7 ✗|→ dotnet test
  Determining projects to restore...
  All projects are up-to-date for restore.
  lib -> /Users/samiz/stripe/csharp-interview-prep/lib/bin/Debug/net8.0/lib.dll
  tests -> /Users/samiz/stripe/csharp-interview-prep/tests/bin/Debug/net8.0/tests.dll
Test run for /Users/samiz/stripe/csharp-interview-prep/tests/bin/Debug/net8.0/tests.dll (.NETCoreApp,Version=v8.0)
Microsoft (R) Test Execution Command Line Tool Version 17.8.0 (arm64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
[xUnit.net 00:00:00.10]     tests.UnitTest1.FailingTest [FAIL]
  Failed tests.UnitTest1.FailingTest [< 1 ms]
  Error Message:
   Assert.True() Failure
Expected: True
Actual:   False
  Stack Trace:
     at tests.UnitTest1.FailingTest() in /Users/samiz/stripe/csharp-interview-prep/tests/UnitTest1.cs:line 26
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

Failed!  - Failed:     1, Passed:     1, Skipped:     0, Total:     2, Duration: 7 ms - tests.dll (net8.0)
02:56:25 samiz@st-samiz2 csharp-interview-prep ±|samiz-dotnet-7 ✗|→ dotnet run
Couldn't find a project to run. Ensure a project exists in /Users/samiz/stripe/csharp-interview-prep, or pass the path to the project using --project.
02:56:44 samiz@st-samiz2 csharp-interview-prep ±|samiz-dotnet-7 ✗|→ dotnet run --project lib
Hello world!
```